### PR TITLE
Add `-e` flag to set sequence for escaping single quotes

### DIFF
--- a/cases/escapes/altrc.out
+++ b/cases/escapes/altrc.out
@@ -1,0 +1,3 @@
+#!/usr/local/bin/rc
+printf %s 'I''m a string with ''single quotes''.
+'

--- a/cases/escapes/default.out
+++ b/cases/escapes/default.out
@@ -1,0 +1,3 @@
+#!/bin/sh
+printf %s 'I'\''m a string with '\''single quotes'\''.
+'

--- a/cases/escapes/input.tpl
+++ b/cases/escapes/input.tpl
@@ -1,0 +1,1 @@
+I'm a string with 'single quotes'.

--- a/cases/escapes/run
+++ b/cases/escapes/run
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+shsub -c input.tpl > default.tmp
+diff -u default.out default.tmp
+
+shsub -s/usr/local/bin/rc -e "''" -c input.tpl > altrc.tmp
+diff -u altrc.out altrc.tmp

--- a/shsub.1.tpl
+++ b/shsub.1.tpl
@@ -50,6 +50,11 @@ Compile the template without execution
 \fB\-o\fR \fIpath\fR
 Set the path of the output script if \fB-c\fR is enabled
 
+.TP
+\fB\-e\fR \fIescape_sequence\fR
+Set the sequence for escaping single quotes
+(default: \fB'\\''\fR)
+
 .SH AUTHORS
 
 Shsub was created by

--- a/shsub.c
+++ b/shsub.c
@@ -31,7 +31,7 @@ struct iframe {
 	enum token lookahead;
 } istack[MAXINCL], *isp = istack;
 
-char *progname, *tmplname, *script;
+char *progname, *tmplname, *script, *esc_seq;
 enum token lookahead;
 int cstack[3], *csp = cstack, lineno = 1;
 char token[MAXTOKEN];
@@ -54,6 +54,7 @@ void syserr(void);
 int main(int argc, char **argv)
 {
 	char *sh = "/bin/sh", tmp[] = "/tmp/shsub.XXXXXX";
+	esc_seq = "'\\''";
 	int fd, op, exe = 1;
 	FILE *in, *out;
 	struct stat st;
@@ -65,7 +66,7 @@ int main(int argc, char **argv)
 		if (!strcmp(argv[1], "--help"))
 			help();
 	}
-	while ((op = getopt(argc, argv, "s:co:")) != -1)
+	while ((op = getopt(argc, argv, "s:co:e:")) != -1)
 		switch (op) {
 		case 's':
 			sh = optarg;
@@ -75,6 +76,9 @@ int main(int argc, char **argv)
 			break;
 		case 'o':
 			script = optarg;
+			break;
+		case 'e':
+			esc_seq = optarg;
 			break;
 		default:
 			err("Call with `--help` for usage");
@@ -279,7 +283,7 @@ void text(int esc, FILE *in, FILE *ou)
 			else if (esc == 1)
 				for (s = token; *s; ++s) {
 					if (*s == '\'')
-						fputs("'\\''", ou);
+						fputs(esc_seq, ou);
 					else
 						fputc(*s, ou);
 				}


### PR DESCRIPTION
Rationale: Some shells, like `rc`, don't support using backslash escapes outside of a quoted string. In order for `shsub` to support such shells without caveats, it is useful to specify an alternative escape sequence for single quotes.

Ref:
- https://doc.cat-v.org/plan_9/4th_edition/papers/rc
- https://github.com/rakitzis/rc